### PR TITLE
Added ability to not show Permission denied alert

### DIFF
--- a/SPPermission.xcodeproj/project.pbxproj
+++ b/SPPermission.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		F4824FEA22ABAAB700A0A487 /* Configuration.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = F4824FE922ABAAB700A0A487 /* Configuration.xcconfig */; };
 		F4F8D4CF22A6E8F500C32329 /* SPPermissionPhotoLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F8D4A822A6E8F500C32329 /* SPPermissionPhotoLibrary.swift */; };
 		F4F8D4D022A6E8F500C32329 /* SPPermissionLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F8D4A922A6E8F500C32329 /* SPPermissionLocation.swift */; };
 		F4F8D4D122A6E8F500C32329 /* SPPermissionMediaLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F8D4AA22A6E8F500C32329 /* SPPermissionMediaLibrary.swift */; };
@@ -258,7 +257,7 @@
 		F4FAD95D225371A20027C912 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1020;
+				LastUpgradeCheck = 1030;
 				ORGANIZATIONNAME = "Ivan Vorobei";
 				TargetAttributes = {
 					F4FAD965225371A20027C912 = {
@@ -272,6 +271,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = F4FAD95C225371A20027C912;
 			productRefGroup = F4FAD967225371A20027C912 /* Products */;
@@ -288,7 +288,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F4824FEA22ABAAB700A0A487 /* Configuration.xcconfig in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SPPermission.xcodeproj/xcshareddata/xcschemes/SPPermission.xcscheme
+++ b/SPPermission.xcodeproj/xcshareddata/xcschemes/SPPermission.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Source/SPPermission/Dialog/Controllers/SPPermissionDialogController.swift
+++ b/Source/SPPermission/Dialog/Controllers/SPPermissionDialogController.swift
@@ -180,23 +180,23 @@ public class SPPermissionDialogController: UIViewController {
                     }
                 } else {
                     self.delegate?.didDenied?(permission: permission)
-                    let alertController = UIAlertController.init(
-                        title:  self.dataSource?.deniedTitle?(for: permission) ?? "Permission denied",
-                        message: self.dataSource?.deniedSubtitle?(for: permission) ?? "Please, go to Settings and allow permissions",
-                        preferredStyle: .alert
-                    )
-                    alertController.addAction(UIAlertAction.init(title: self.dataSource?.cancelTitle ?? "Cancel", style: UIAlertAction.Style.cancel, handler: nil))
-                    alertController.addAction(UIAlertAction.init(title: self.dataSource?.settingsTitle ?? "Settings", style: UIAlertAction.Style.default, handler: { (action) in
-                        
-                        UIApplication.shared.open(
-                            URL.init(string: UIApplication.openSettingsURLString)!,
-                            options: [:],
-                            completionHandler: nil
+                    if self.dataSource?.showAlertIfDenied ?? true {
+                        let alertController = UIAlertController.init(
+                            title:  self.dataSource?.deniedTitle?(for: permission) ?? "Permission denied",
+                            message: self.dataSource?.deniedSubtitle?(for: permission) ?? "Please, go to Settings and allow permissions",
+                            preferredStyle: .alert
                         )
-                        
-                    }))
-                    
-                    self.present(alertController, animated: true, completion: nil)
+                        alertController.addAction(UIAlertAction.init(title: self.dataSource?.cancelTitle ?? "Cancel", style: UIAlertAction.Style.cancel, handler: nil))
+                        alertController.addAction(UIAlertAction.init(title: self.dataSource?.settingsTitle ?? "Settings", style: UIAlertAction.Style.default, handler: { (action) in
+                            UIApplication.shared.open(
+                                URL.init(string: UIApplication.openSettingsURLString)!,
+                                options: [:],
+                                completionHandler: nil
+                            )
+                        }))
+
+                        self.present(alertController, animated: true, completion: nil)
+                    }
                 }
             })
         }

--- a/Source/SPPermission/Dialog/SPPermissionDialog.swift
+++ b/Source/SPPermission/Dialog/SPPermissionDialog.swift
@@ -70,6 +70,7 @@ extension SPPermission {
     @objc optional var allowedTitle: String { get }
     @objc optional var bottomComment: String { get }
     @objc optional var showCloseButton: Bool { get }
+    @objc optional var showAlertIfDenied: Bool { get } // default value is true
     @objc optional var dragEnabled: Bool { get }
     @objc optional var isDismissable: Bool { get }
     @objc optional func name(for permission: SPPermissionType) -> String?


### PR DESCRIPTION
Right now if app request `locationAlwaysAndWhenInUse` permission and user allow `locationWhenInUse` it will show alert "Permission denied". But in some cases it is ok, so I have added ability to `SPPermissionDialogDataSource` decide if need to show this alert.